### PR TITLE
Enable Depth Mode Configuration

### DIFF
--- a/Assets/Akvfx/DeviceSettings.cs
+++ b/Assets/Akvfx/DeviceSettings.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Microsoft.Azure.Kinect.Sensor;
 
 namespace Akvfx
 {
@@ -22,6 +23,8 @@ namespace Akvfx
         [SerializeField] bool _powerIs60Hz = true;
 
         [SerializeField, Range(0, 6.6f)] float _maxDepth = 1;
+
+        [SerializeField] DepthMode _depthMode = DepthMode.NFOV_Unbinned;
 
         #endregion
 
@@ -85,6 +88,11 @@ namespace Akvfx
         public float maxDepth {
             get { return _maxDepth; }
             set { _maxDepth = value; }
+        }
+
+        public DepthMode depthMode {
+            get { return _depthMode; }
+            set { _depthMode = value; }
         }
 
         #endregion

--- a/Assets/Akvfx/Editor/DeviceSettingsEditor.cs
+++ b/Assets/Akvfx/Editor/DeviceSettingsEditor.cs
@@ -24,6 +24,8 @@ namespace Akvfx
 
         SerializedProperty _maxDepth;
 
+        SerializedProperty _depthMode;
+
         static readonly (
             GUIContent enableBlc,
             GUIContent powerIs60Hz
@@ -50,6 +52,8 @@ namespace Akvfx
             _powerIs60Hz = serializedObject.FindProperty("_powerIs60Hz");
 
             _maxDepth = serializedObject.FindProperty("_maxDepth");
+
+            _depthMode = serializedObject.FindProperty("_depthMode");
         }
 
         public override void OnInspectorGUI()
@@ -84,6 +88,8 @@ namespace Akvfx
             EditorGUILayout.PropertyField(_powerIs60Hz, _labels.powerIs60Hz);
 
             EditorGUILayout.PropertyField(_maxDepth);
+
+            EditorGUILayout.PropertyField(_depthMode);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/Akvfx/Internal/K4aExtensions.cs
+++ b/Assets/Akvfx/Internal/K4aExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.Azure.Kinect.Sensor;
 
 namespace Akvfx
 {
@@ -24,6 +25,44 @@ namespace Akvfx
             );
 
             safeCopyNativeBuffers.SetValue(singleton.GetValue(null), false);
+        }
+
+        /// <summary> Return the width of the associated DepthMode Texture </summary>
+        public static int Width(this DepthMode mode) {
+            switch (mode) {
+                case DepthMode.Off:
+                    return 0;
+                case DepthMode.NFOV_2x2Binned:
+                    return 320;
+                case DepthMode.NFOV_Unbinned:
+                    return 640;
+                case DepthMode.PassiveIR:
+                    return 1024;
+                case DepthMode.WFOV_2x2Binned:
+                    return 512;
+                case DepthMode.WFOV_Unbinned:
+                    return 1024;
+            }
+            return 0;
+        }
+
+        /// <summary> Return the height of the associated DepthMode Texture </summary>
+        public static int Height(this DepthMode mode) {
+            switch (mode) {
+                case DepthMode.Off:
+                    return 0;
+                case DepthMode.NFOV_2x2Binned:
+                    return 288;
+                case DepthMode.NFOV_Unbinned:
+                    return 576;
+                case DepthMode.PassiveIR:
+                    return 1024;
+                case DepthMode.WFOV_2x2Binned:
+                    return 512;
+                case DepthMode.WFOV_Unbinned:
+                    return 1024;
+            }
+            return 0;
         }
     }
 }

--- a/Assets/Akvfx/Internal/ThreadedDriver.cs
+++ b/Assets/Akvfx/Internal/ThreadedDriver.cs
@@ -106,14 +106,17 @@ namespace Akvfx
                 new DeviceConfiguration {
                     ColorFormat = ImageFormat.ColorBGRA32,
                     ColorResolution = ColorResolution.R1536p, // 2048 x 1536 (4:3)
-                    DepthMode = DepthMode.NFOV_Unbinned,      // 640x576
+                    DepthMode =  _settings.depthMode,
+                    CameraFPS = (_settings.depthMode == DepthMode.WFOV_Unbinned) ?
+                                    FPS.FPS15 : FPS.FPS30,
                     SynchronizedImagesOnly = true
                 }
             );
 
             // Construct XY table as a background task.
             Task.Run(() => {
-                _xyTable = new XYTable(device.GetCalibration(), 640, 576);
+                _xyTable = new XYTable(device.GetCalibration(), device.CurrentDepthMode.Width (), 
+                                                                device.CurrentDepthMode.Height());
             });
 
             // Set up the transformation object.

--- a/Assets/Akvfx/Internal/Unproject.shader
+++ b/Assets/Akvfx/Internal/Unproject.shader
@@ -8,6 +8,8 @@
     Buffer<uint> _DepthBuffer;
     Buffer<float> _XYTable;
     float _MaxDepth;
+    float _Width;
+    float _Height;
 
     float3 uint_to_float3(uint raw)
     {
@@ -40,7 +42,7 @@
     )
     {
         // Buffer index
-        uint idx = (uint)(uv.x * 640) + (uint)((1 - uv.y) * 576) * 640;
+        uint idx = (uint)(uv.x * _Width) + (uint)((1 - uv.y) * _Height) * _Width;
 
         // Color sample
         float3 color = GammaToLinearSpace(uint_to_float3(_ColorBuffer[idx]));

--- a/Assets/Akvfx/PointCloudBaker.cs
+++ b/Assets/Akvfx/PointCloudBaker.cs
@@ -32,6 +32,8 @@ namespace Akvfx
             public static readonly int DepthBuffer = Shader.PropertyToID("_DepthBuffer");
             public static readonly int XYTable     = Shader.PropertyToID("_XYTable");
             public static readonly int MaxDepth    = Shader.PropertyToID("_MaxDepth");
+            public static readonly int Width       = Shader.PropertyToID("_Width");
+            public static readonly int Height      = Shader.PropertyToID("_Height");
         }
 
         #endregion
@@ -45,8 +47,11 @@ namespace Akvfx
 
             // Temporary objects for convertion shader
             _material = new Material(_shader);
-            _colorBuffer = new ComputeBuffer(640 * 576, 4);
-            _depthBuffer = new ComputeBuffer(640 * 576 / 2, 4);
+
+            _colorBuffer = new ComputeBuffer(_deviceSettings.depthMode.Width () * 
+                                             _deviceSettings.depthMode.Height() * 4, 4);
+            _depthBuffer = new ComputeBuffer(_deviceSettings.depthMode.Width () * 
+                                             _deviceSettings.depthMode.Height() * 4 / 2, 4);
         }
 
         void OnDestroy()
@@ -89,6 +94,8 @@ namespace Akvfx
             _material.SetBuffer(ID.DepthBuffer, _depthBuffer);
             _material.SetBuffer(ID.XYTable, _xyTable);
             _material.SetFloat(ID.MaxDepth, _deviceSettings.maxDepth);
+            _material.SetInt(ID.Width, _deviceSettings.depthMode.Width());
+            _material.SetInt(ID.Height, _deviceSettings.depthMode.Height());
 
             var prevRT = RenderTexture.active;
             GraphicsExtensions.SetRenderTarget(_colorTexture, _positionTexture);

--- a/Assets/Akvfx/SurfaceRenderer.cs
+++ b/Assets/Akvfx/SurfaceRenderer.cs
@@ -10,6 +10,7 @@ namespace Akvfx
         #region Editable attributes
 
         [SerializeField] Material _material = null;
+        [SerializeField] DeviceSettings _deviceSettings = null;
 
         #endregion
 
@@ -24,7 +25,9 @@ namespace Akvfx
         void Start()
         {
             _mesh = new Mesh();
-            ConstructMesh();
+            _mesh.indexFormat = IndexFormat.UInt32;
+            ConstructMesh(_deviceSettings.depthMode.Width (), 
+                          _deviceSettings.depthMode.Height());
         }
 
         void OnDestroy()
@@ -45,10 +48,10 @@ namespace Akvfx
 
         #region Mesh object operations
 
-        void ConstructMesh()
+        void ConstructMesh(int width, int height)
         {
-            const int columns = 640;
-            const int rows = 576;
+            int columns = width;
+            int rows = height;
 
             using (var vertices = BuildVertexArray(columns, rows))
             {

--- a/Assets/Buffer/Color.renderTexture
+++ b/Assets/Buffer/Color.renderTexture
@@ -13,8 +13,8 @@ RenderTexture:
   m_ForcedFallbackFormat: 4
   m_DownscaleFallback: 0
   serializedVersion: 3
-  m_Width: 640
-  m_Height: 576
+  m_Width: 1024
+  m_Height: 1024
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthFormat: 0

--- a/Assets/Buffer/Position.renderTexture
+++ b/Assets/Buffer/Position.renderTexture
@@ -13,8 +13,8 @@ RenderTexture:
   m_ForcedFallbackFormat: 4
   m_DownscaleFallback: 0
   serializedVersion: 3
-  m_Width: 640
-  m_Height: 576
+  m_Width: 1024
+  m_Height: 1024
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthFormat: 0

--- a/Assets/Test.unity
+++ b/Assets/Test.unity
@@ -941,6 +941,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _material: {fileID: 2100000, guid: 72cda23ef2f5c2d43b6c7fd132cb9081, type: 2}
+  _deviceSettings: {fileID: 11400000, guid: 78d2d0c19822b07428bb2b8b4ed7c2fb, type: 2}
 --- !u!4 &510216872
 Transform:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.0f6
-m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)
+m_EditorVersion: 2019.3.7f1
+m_EditorVersionWithRevision: 2019.3.7f1 (6437fd74d35d)


### PR DESCRIPTION
This PR adds the Depth Mode to the `KinectSettings.asset`, allowing the resolution and field of view of the Depth Image to be configured from the inspector on that asset.

See [this page](https://docs.microsoft.com/bs-latn-ba/azure/Kinect-dk/hardware-specification#depth-camera-supported-operating-modes) for available depth modes.